### PR TITLE
fix docs

### DIFF
--- a/pages/index.md
+++ b/pages/index.md
@@ -40,11 +40,11 @@ cover-subtitle: 标题下方的小字 # 可选
 
 {% folding 显示效果 open:false %}
 
-只填写 `cover-title` 或填写 `cover-title` 与 `cover-cat` 时大标题位于上方
+填写 `cover-title` 与 `cover-cat` 时大标题位于上方
 
 {% image https://pic1.imgdb.cn/item/635aa9d016f2c2beb1fe4f53.jpg width:600px %}
 
-填写 `cover-title` 与 `cover-subtitle` 时大标题位于下方
+只填写 `cover-title` 或填写 `cover-title` 与 `cover-subtitle` 时大标题位于下方
 
 {% image https://pic1.imgdb.cn/item/635aaa8116f2c2beb1ffdd19.jpg width:600px %}
 


### PR DESCRIPTION
只填写 `cover-title`  时大标题应位于下方：

![image](https://user-images.githubusercontent.com/104631897/198832364-61812eba-5149-4527-8b9e-a988324ac7f5.png)
